### PR TITLE
fix: work around tail call optimization failure bug in compiler

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "zwilias/elm-html-string",
     "summary": "A drop-in elm/html replacement that can stringify to a pretty HTML string",
     "license": "BSD-3-Clause",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "exposed-modules": [
         "Html.String",
         "Html.String.Attributes",

--- a/src/Html/Types.elm
+++ b/src/Html/Types.elm
@@ -235,38 +235,43 @@ toStringHelper indenter tags acc =
                     acc
 
                 ( tagName, cont ) :: rest ->
-                    { acc
-                        | result = indenter (acc.depth - 1) (closingTag tagName) :: acc.result
-                        , depth = acc.depth - 1
-                        , stack = rest
-                    }
-                        |> toStringHelper indenter cont
+                    toStringHelper indenter
+                        cont
+                        { acc
+                            | result = indenter (acc.depth - 1) (closingTag tagName) :: acc.result
+                            , depth = acc.depth - 1
+                            , stack = rest
+                        }
 
         (Node tagName attributes children) :: rest ->
             case children of
                 NoChildren ->
-                    { acc | result = indenter acc.depth (tag tagName attributes) :: acc.result }
-                        |> toStringHelper indenter rest
+                    toStringHelper indenter
+                        rest
+                        { acc | result = indenter acc.depth (tag tagName attributes) :: acc.result }
 
                 Regular childNodes ->
-                    { acc
-                        | result = indenter acc.depth (tag tagName attributes) :: acc.result
-                        , depth = acc.depth + 1
-                        , stack = ( tagName, rest ) :: acc.stack
-                    }
-                        |> toStringHelper indenter childNodes
+                    toStringHelper indenter
+                        childNodes
+                        { acc
+                            | result = indenter acc.depth (tag tagName attributes) :: acc.result
+                            , depth = acc.depth + 1
+                            , stack = ( tagName, rest ) :: acc.stack
+                        }
 
                 Keyed childNodes ->
-                    { acc
-                        | result = indenter acc.depth (tag tagName attributes) :: acc.result
-                        , depth = acc.depth + 1
-                        , stack = ( tagName, rest ) :: acc.stack
-                    }
-                        |> toStringHelper indenter (List.map Tuple.second childNodes)
+                    toStringHelper indenter
+                        (List.map Tuple.second childNodes)
+                        { acc
+                            | result = indenter acc.depth (tag tagName attributes) :: acc.result
+                            , depth = acc.depth + 1
+                            , stack = ( tagName, rest ) :: acc.stack
+                        }
 
         (TextNode string) :: rest ->
-            { acc | result = indenter acc.depth string :: acc.result }
-                |> toStringHelper indenter rest
+            toStringHelper indenter
+                rest
+                { acc | result = indenter acc.depth string :: acc.result }
 
 
 tag : String -> List (Attribute msg) -> String


### PR DESCRIPTION
tail call optimization fails when pipes are used https://github.com/elm/compiler/issues/1770.

When tail call optimization fails, we see node stack RangeError when converting a medium size view into a string.